### PR TITLE
Add Vimshell plugin to .vimrc.bundles.local

### DIFF
--- a/.vimrc.bundles.local
+++ b/.vimrc.bundles.local
@@ -15,7 +15,7 @@ NeoBundle 'tpope/vim-fugitive'
 NeoBundle 'tpope/vim-surround'
 NeoBundle 'flazz/vim-colorschemes'
 "TODO: Add vimproc
-"TODO: Add Vimshell
+NeoBundle 'Shougo/vimshell'
 "TODO: Add eclim
 "Vundle NeoBundles!
 NeoBundle 'Chiel92/vim-autoformat'


### PR DESCRIPTION
This change adds the 'Vimshell' plugin to the NeoBundle configuration in .vimrc.bundles.local as requested. It replaces the TODO comment with the actual NeoBundle command for Shougo/vimshell.

---
*PR created automatically by Jules for task [500406537604791499](https://jules.google.com/task/500406537604791499) started by @tstapler*