### PR TITLE
🔒 Fix unsafe curl pipe to bash in pyenv installation scripts

### DIFF
--- a/stapler-scripts/bootstrap-dotfiles.sh
+++ b/stapler-scripts/bootstrap-dotfiles.sh
@@ -6,7 +6,17 @@ DOTFILES_REPO="tstapler/$REPO_NAME"
 
 # Install python
 if ! [ -d "$HOME/.pyenv/" ]; then
-  curl https://pyenv.run | bash
+  echo "Downloading pyenv installer..."
+  installer_script=$(mktemp)
+  if curl -fsSL https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer -o "$installer_script"; then
+    echo "Running pyenv installer..."
+    bash "$installer_script"
+    rm "$installer_script"
+  else
+    echo "Failed to download pyenv installer"
+    rm "$installer_script"
+    exit 1
+  fi
 fi
 
 PYTHON_VERSION=3.9.12

--- a/stapler-scripts/install-scripts/pyenv-install.sh
+++ b/stapler-scripts/install-scripts/pyenv-install.sh
@@ -1,5 +1,13 @@
 #Install pyenv
 if [ ! -d ~/.pyenv ]; then
     echo "Installing pyenv"
-    curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+    installer_script=$(mktemp)
+    if curl -fsSL https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer -o "$installer_script"; then
+        bash "$installer_script"
+        rm "$installer_script"
+    else
+        echo "Failed to download pyenv installer"
+        rm "$installer_script"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
This PR addresses a security vulnerability where `curl` output was piped directly to `bash` for installing `pyenv`. This pattern is unsafe because a interrupted download could lead to partial script execution.

The fix involves:
1.  Downloading the installer script to a secure temporary file using `mktemp`.
2.  Checking the exit code of `curl` to ensure the download completed successfully.
3.  Executing the script from the local file.
4.  Cleaning up the temporary file.

This change was applied to `stapler-scripts/bootstrap-dotfiles.sh` and `stapler-scripts/install-scripts/pyenv-install.sh`. Additionally, the URL for `pyenv-installer` was updated to the canonical `pyenv/pyenv-installer` repository.

---
*PR created automatically by Jules for task [5040471773561422884](https://jules.google.com/task/5040471773561422884) started by @tstapler*